### PR TITLE
INF-1228 fix docker-compose bug in dind img

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 ENV DOCKER_VERSION=1.13.1 \
-  DOCKER_COMPOSE_VERSION=1.10.1 \
+  DOCKER_COMPOSE_VERSION=1.20.1 \
   DOCKER_PACKAGES="curl device-mapper mkinitfs bash e2fsprogs e2fsprogs-extra iptables python-dev" \
   OTHER="git"
 


### PR DESCRIPTION
Upgrade docker-compose in our `dind` container to fix a bug where it can't create a container if a symlink exists that points to a non-existent target.  

The error showed itself in smart_api PR builder after the mongo gem was updated to a version which included such a symlink.  This results in the following type error:
```
  File "/usr/lib/python2.7/site-packages/docker/utils/utils.py", line 103, in create_archive

    'Can not access file in context: {}'.format(full_path)

IOError: Can not access file in context: /tmp/build/dfbe9b8f/repo/vendor/bundle/ruby/2.6.0/gems/mongo-2.18.2/spec/support/ocsp

Docker Compose Failed
```